### PR TITLE
Added 'Square root of a number' dated 13th August 2024

### DIFF
--- a/August 2024/(Square root of a number) dated 13th August 2024
+++ b/August 2024/(Square root of a number) dated 13th August 2024
@@ -1,0 +1,8 @@
+#User function Template for python3
+import math as m
+
+#Complete this function
+class Solution:
+    def floorSqrt(self, n): 
+    #Your code here
+        return m.floor(n ** 0.5)


### PR DESCRIPTION
The solution for the problem `Square root of a number` dated `13th August 2024` is working fine.

The screenshot is as follows:

![Screenshot 2024-10-10 134708](https://github.com/user-attachments/assets/923ea8dc-4941-4852-845b-377aaee7a0e5)

Please Review and add the `hacktoberfest` label.