### PR TITLE
Created Paths from root with a specified sum.cpp

### DIFF
--- a/January 2024/Paths from root with a specified sum.cpp
+++ b/January 2024/Paths from root with a specified sum.cpp
@@ -1,0 +1,36 @@
+#GFG POTD 22 JAN 2024
+# Paths from root with a specified sum
+# cpp Program 
+
+class Solution
+{
+    public:
+    vector<vector<int>> printPaths(Node *root, int sum)
+    {
+        //code here
+        vector<vector<int>> ans;
+        vector<int> p;
+        
+        
+        function(root, 0, sum, ans, p);
+        
+        return ans;
+    }
+    
+    void function(Node * root, int curr, int sum, vector<vector<int>> & ans, vector<int> p)
+    {
+        if(root==NULL){
+            return;
+        }
+        
+        curr=curr+root->key;
+        p.push_back(root->key);
+        if(curr==sum){
+            ans.push_back(p);
+        }
+        
+        function(root->left, curr, sum, ans, p);
+        function(root->right, curr, sum, ans, p);
+        
+    }
+};


### PR DESCRIPTION
Paths from root with a specified sum

Given a Binary tree and a sum S, print all the paths, starting from root, that sums upto the given sum. Path not necessarily end on a leaf node.

Added the solution for gfg potd 22 jan 2024

![image](https://github.com/user-attachments/assets/98bb392c-d4ea-4201-b5e0-0b4cdb8762db)
