### PR TITLE
Create Reverse First K elements of Queue(12 JAN  GFG POTD)

### DIFF
--- a/January 2024/Reverse First K elements of Queue(12 JAN  GFG POTD)
+++ b/January 2024/Reverse First K elements of Queue(12 JAN  GFG POTD)
@@ -1,0 +1,34 @@
+class Solution
+{
+    public:
+    
+    // Function to reverse first k elements of a queue.
+    queue<int> modifyQueue(queue<int> q, int k) {
+        
+       deque< int >dq ;
+       int i = 1 ;
+       int remain = q.size() - k ;
+       while( i <= k )
+       {
+           dq.push_front( q.front() );
+           q.pop();
+           i++ ;
+       }
+       
+       int j = 1 ;
+       while( j <= remain )
+       {
+           dq.push_back( q.front() );
+           q.pop();
+           j++ ;
+       }
+       
+       while( !dq.empty() )
+       {
+           q.push( dq.front() );
+           dq.pop_front();
+       }
+       
+       return q ;
+    }
+};


### PR DESCRIPTION
Initialization:
A deque<int> named dq is created to temporarily hold elements. Two integers, i and remain, are initialized. i is set to 1, and remain is calculated as the size of the queue q minus k. Reversing the First k Elements:
A while loop runs k times, pushing the front element of q to the front of dq and then popping it from q. This effectively reverses the order of the first k elements of q. Appending the Remaining Elements:
Another while loop runs for the remaining elements (i.e., remain times), pushing the front element of q to the back of dq and then popping it from q. This keeps the order of the remaining elements unchanged. Reconstructing the Queue:
A final while loop runs until dq is empty, pushing the front element of dq back into q and then popping it from dq. This reconstructs q with the first k elements reversed and the remaining elements in their original order. Return:
The modified queue q is returned