### PR TITLE
Create Arrange Consonants and Vowels_1MAY_GFG_POTD

### DIFF
--- a/May 2024/Arrange Consonants and Vowels_1MAY_GFG_POTD
+++ b/May 2024/Arrange Consonants and Vowels_1MAY_GFG_POTD
@@ -1,0 +1,37 @@
+class Solution {
+  public:
+    struct Node *arrangeCV(Node *head) {
+        if (!head || !head->next) return head; // If list is empty or has one element
+        Node *vowelHead = nullptr, *vowelTail = nullptr;
+        Node *consonantHead = nullptr, *consonantTail = nullptr;
+        auto isVowel = [](char c) {
+            return c == 'a' || c == 'e' || c == 'i' || c == 'o' || c == 'u';
+        };
+        Node* current = head;
+        while (current) {
+            if (isVowel(current->data)) {
+                // Add to vowel list
+                if (!vowelHead) {
+                    vowelHead = vowelTail = current;
+                } else {
+                    vowelTail->next = current;
+                    vowelTail = vowelTail->next;
+                }
+            } else {
+                if (!consonantHead) {
+                    consonantHead = consonantTail = current;
+                } else {
+                    consonantTail->next = current;
+                    consonantTail = consonantTail->next;
+                }
+            }
+            current = current->next;
+        }
+        if (vowelTail) {
+            vowelTail->next = consonantHead;
+        }
+        if (consonantTail) {
+            consonantTail->next = nullptr; }
+        return vowelHead ? vowelHead : consonantHead;
+    }
+};


### PR DESCRIPTION

![1_may_gfg](https://github.com/user-attachments/assets/6b2c16e2-0a56-4ab5-8eb0-fd1666567f5b)
![1_may_gfg_11](https://github.com/user-attachments/assets/81ff524c-cb2b-4745-9352-feac4957a5bd)

This function rearranges a linked list so that all vowels appear before consonants while maintaining their original order. It creates separate lists for vowels and consonants, then merges them, ensuring a linear time solution.

Kindly assign me this
