### PR TITLE
Create split_the_array_(21_october_2024_).py

### DIFF
--- a/October 2024/split_the_array_(21_october_2024_).py
+++ b/October 2024/split_the_array_(21_october_2024_).py
@@ -1,0 +1,13 @@
+class Solution:
+    def countgroup(self, arr):
+        mod = int(1e9 + 7)
+        xr = 0
+        n = len(arr)
+        for num in arr:
+            xr ^= num
+        if xr != 0:
+            return 0
+        ans = 1
+        for _ in range(n - 1):
+            ans = (ans * 2) % mod
+        return ans - 1


### PR DESCRIPTION
Given an array arr[] of integers, the task is to count the number of ways to split given array elements into two non-empty subsets such that the XOR of elements of each group is equal. Each element should belong to exactly one subset.
Note:

1. The answer could be very large so print it by doing modulo with 109 + 7. 
2. Subsets with the same elements but derived from different indices are different.
 This is the solution for the above question given in the file.
<img width="1512" alt="Screenshot 2024-10-30 at 1 26 47 PM" src="https://github.com/user-attachments/assets/f7d8a3bb-c27b-4ee4-9352-c951d568c38e">

